### PR TITLE
Creates rake task - olympic_data:import_2016

### DIFF
--- a/lib/tasks/olympic_data.rake
+++ b/lib/tasks/olympic_data.rake
@@ -1,0 +1,35 @@
+require 'csv'
+
+namespace :olympic_data do
+  desc "imports olympic data from 2016 summer games"
+  task import_2016: :environment do
+
+    CSV.foreach('./db/olympic_data_2016.csv', headers: true) do |row|
+
+      country = row['Team'].split('-')[0]
+
+      team = Team.find_or_create_by(country_name: country)
+
+      olympian = Olympian.find_or_create_by(name: row['Name']) do |olympian|
+        olympian.sex = row['Sex']
+        olympian.age = row['Age']
+        olympian.height = row['Height']
+        olympian.weight = row['Weight']
+        olympian.team = team
+      end
+
+      sport = Sport.find_or_create_by(sport_name: row['Sport'])
+
+      event = Event.find_or_create_by(event_name: row['Event']) do |event|
+        event.sport = sport
+      end
+
+      OlympianEvent.create(
+        games: row['Games'],
+        medal: row['Medal'],
+        olympian_id: olympian.id,
+        event_id: event.id
+      )
+    end
+  end
+end


### PR DESCRIPTION
- [ ] Check this if the PR has been approved by the team to be a quick patch and the rest of this form will not be filled out

## What functionality does this accomplish?
closes #22

**Description:**
Created a Rake Task for importing our `olympic_data_2016.csv` file into our database. This file contains **3485** unique records. 

- From the command line, ran: `$ rails g task olympic_data import_2016` - which created `/lib/tasks/olympic_data.rake` - where our logic for this task will be.

- `$ rails olympic_data:import_2016` - will run our rake task and import the data into our **5** tables (`teams`, `olympians`, `olympian_events`, `events`, `sports`) accordingly, where our relationships are already set up.
- This task takes about **35 seconds** - only iterates through the CSV data file one time, but this is a little long.
- Results in the following unique records for each table:
```
Team.count => 178
Olympian.count => 2850
OlympianEvent.count => 3485
Event.count => 305
Sport.count => 34
```
 - *relationship validations were spot checked in Rails Console (`$rails c`)*  


Here is the code in :`olympic_data.rake`
```
require 'csv'

namespace :olympic_data do
  desc "imports olympic data from 2016 summer games"
  task import_2016: :environment do

    CSV.foreach('./db/olympic_data_2016.csv', headers: true) do |row|

      country = row['Team'].split('-')[0]

      team = Team.find_or_create_by(country_name: country)

      olympian = Olympian.find_or_create_by(name: row['Name']) do |olympian|
        olympian.sex = row['Sex']
        olympian.age = row['Age']
        olympian.height = row['Height']
        olympian.weight = row['Weight']
        olympian.team = team
      end

      sport = Sport.find_or_create_by(sport_name: row['Sport'])

      event = Event.find_or_create_by(event_name: row['Event']) do |event|
        event.sport = sport
      end

      OlympianEvent.create(
        games: row['Games'],
        medal: row['Medal'],
        olympian_id: olympian.id,
        event_id: event.id
      )
    end
  end
end
```
## What did you struggle on to complete?
`find_or_create_by` syntax when finding by one attribute, but then needing to include other attributes upon creation. *(helpful docs below)*

Without much experience creating rake tasks, I needed to look up how to do that. The next hurdle was determining how to pull out column headers and apply them to different models. I had to do a little looking around but was able to figure it out by creating instance of Models, and piecing relationships together with these. *(helpful docs below)*

## Current Test Suite:
### Test Coverage Percentage: 100%
- [ ] Tests have been added
- [x] No Tests have been changed
- [ ] Some Tests have been changed

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
- [ ] I have partially tested my code (please explain why):

## Helpful Resources:
Resource link AND small description of info gathered/learned
- [API Dock](https://apidock.com/rails/v4.0.2/ActiveRecord/Relation/find_or_create_by?source=post_page---------------------------) - this was where I found syntax for finding by one attribute, and then creating by multiple attributes.

- [Stack Overflow: "Ruby - CSV Import split data into different tables" ](https://stackoverflow.com/questions/45532724/ruby-csv-import-split-data-into-different-tables) - good starting point for realizing that we could abstract data from each column title and use as we please.

- [Generating a Rake Task - Rails](https://railsguides.net/how-to-generate-rake-task/) - Simple walkthrough and syntax on how to generate a rake task from the command line.

## Review Requests(optional):
@seansmith1020 - is this what good PR's look like?

## Please include an emoji of how you feel about this branch:
🐢🏅