### PR TITLE
Api v1 olympians stats endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,35 @@ body:
 }
 ```
 ---
+**GET /api/v1/olympian_stats**  
+Returns overall olympian statistics including: total competitors, average weight by gender, and average age for all olympians.
+
+Required Parameters:
+`no required parameters`
+
+Example Request:
+`GET https://koroibos-2016.herokuapp.com/api/v1/olympian_stats`
+```
+Request:
+Content-Type: application/json
+Accept: application/json
+```
+```
+Response:
+status: 200
+body:
+{
+  olympian_stats: {
+    total_competing_olympians: 2850,
+    average_weight: {
+      unit: "kg",
+      male_olympians: 77.9,
+      female_olympians: 61.4
+    },
+    average_age: 26.4
+  }
+}
+```
 
 ### Schema
 ![schema](korobois_schema.png)

--- a/app/controllers/api/v1/olympian_stats_controller.rb
+++ b/app/controllers/api/v1/olympian_stats_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::OlympianStatsController < ApplicationController
+
+  def index
+    render json: Olympian.class, serializer: OlympianStatsSerializer, root: 'olympian_stats'
+  end
+
+end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -20,6 +20,15 @@ class Olympian < ApplicationRecord
     where(age: maximum(:age))
   end
 
+  def self.average_weight(gender)
+    key = gender[0].upcase
+    where(sex: key).average(:weight).to_f.round(1)
+  end
+
+  def self.average_age
+    average(:age).to_f.round(1)
+  end
+
   def country
     team.country_name
   end

--- a/app/serializers/olympian_stats_serializer.rb
+++ b/app/serializers/olympian_stats_serializer.rb
@@ -1,0 +1,20 @@
+class OlympianStatsSerializer < ActiveModel::Serializer
+  attributes :total_competing_olympians, :average_weight, :average_age
+
+  def total_competing_olympians
+    Olympian.count
+  end
+
+  def average_weight
+    {
+      "unit" => 'kg',
+      "male_olympians" => Olympian.average_weight("M"),
+      "female_olympians" => Olympian.average_weight("F")
+    }
+  end
+
+  def average_age
+    Olympian.average_age
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get '/olympians', to: 'olympians#index'
+      get '/olympian_stats', to: 'olympian_stats#index'
     end
   end
 

--- a/spec/requests/api/v1/olympian_stats_request_spec.rb
+++ b/spec/requests/api/v1/olympian_stats_request_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe 'Olympian Stats API' do
+  context 'GET api/v1/olympian_stats' do
+    
+    it 'returns overall olympians stats - total, avg age, avg weight' do
+      create(:olympian, name:'Abbey', sex: 0, age: 27, height: 160, weight: 58)
+      create(:olympian, name:'Betsy', sex: 0, age: 30, height: 167, weight: 61)
+      create(:olympian, name:'Corey', sex: 1, age: 31, height: 182, weight: 82)
+      create(:olympian, name:'Derek', sex: 1, age: 39, height: 188, weight: 85)
+
+      get '/api/v1/olympian_stats'
+
+      olympian_stats = JSON.parse(response.body)
+
+      expected =  {
+                    "olympian_stats" => {
+                      "total_competing_olympians" => 4,
+                      "average_weight" => {
+                        "unit" => "kg",
+                        "male_olympians" => 83.5,
+                        "female_olympians" => 59.5
+                      },
+                      "average_age" => 31.8
+                    }
+                  }
+
+      expect(response.status).to eq(200)
+      expect(olympian_stats).to eq(expected)
+    end
+  end
+
+end


### PR DESCRIPTION
- [ ] Check this if the PR has been approved by the team to be a quick patch and the rest of this form will not be filled out

## What functionality does this accomplish?
closes #9 

**Description:**
Overall **Olympian Statistics** can be found by `GET api/v1/olympian_stats`
*Example Response*:
```
olympian_stats: {
    total_competing_olympians: 2850,
    average_weight: {
        unit: "kg",
        male_olympians: 77.9,
        female_olympians: 61.4
    },
  average_age: 26.4
}
```
- Created Route: `api/v1/olympian_stats`
- Created Controller: `api/v1/olympian_stats_controller`
- Created Serializer: `serializers/olympian_stats_serializer`

## What did you struggle on to complete?
This was a challenging  branch... 

The first issue that I struggled with was how use a specified Serializer for a Model. Since we already have an OlympianSerializer, when we tried to render anything associated with the Olympian class, this is the serializer that it would default to.

We needed to have a different formatting of data, which necessitated a separate OlympianStatsSerializer. We were able to specify this in our controller by using `serializer:` after the object being passed in.
```
  def index
    render json: Olympian.class, serializer: OlympianStatsSerializer, root: 'olympian_stats'
  end
``` 
This brings us to the next point - where we are passing in `Olympian.class`. It looks and feels a little hacky, but something needs to be passed into our serializer. To use a custom serializer on an `array of objects`, you use `each_serializer:`, and `serializer:` for an individual `instance` of a class. I was unable to find a cleaner way to pass in a class as a whole to the serializer.

In this case, `Olympian.class` is merely a placeholder - which conveys what we are trying to do - (this could be the string "zebra" right now and things still work"). This is because our interaction with the `Olympian` class does not happen until we get to the serializer - where we call class methods on `Olympian`, rather than on an `object` as we normally would with ActiveModelSerializer:
*Example*:
```
class OlympianStatsSerializer < ActiveModel::Serializer
  attributes :total_competing_olympians, :average_weight, :average_age

  def total_competing_olympians
    Olympian.count
  end
...
```

The second major issue came when testing in `$ Rails S`. Everything worked great when I visited the endpoint, however when I hit refresh, we would receive this error:
```
uninitialized constant OlympianStatsSerializer
```
After a lot of playing around and reaching out for advice, I was able to fix this issue by taking the `OlympianStatsSerializer` out of the `api/v1` name spacing, and placed it at the root of the `serializers` directory. I am not sure why Rails was able to access this file on the first visit to the endpoint and not afterwards, but moving the location of this serializer fixed the issue.

Due to time constraints, and the fact the things are working as intended - I felt like it was good to submit this code in a PR. If future time allows, or it is determined to be a priority - this code can certainly be looked at for refactoring.

## Current Test Suite:
### Test Coverage Percentage: 100%
- [x] Tests have been added
- [ ] No Tests have been changed
- [ ] Some Tests have been changed

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
- [ ] I have partially tested my code (please explain why):

## Helpful Resources:
Resource link AND small description of info gathered/learned

Hints on how to specify using a certain serializer:
- [https://www.rubydoc.info/gems/active_model_serializers/0.9.4](https://www.rubydoc.info/gems/active_model_serializers/0.9.4)
-[How to implement multiple different serializers for same model using ActiveModel::Serializers?](https://stackoverflow.com/questions/12485404/how-to-implement-multiple-different-serializers-for-same-model-using-activemodel?source=post_page---------------------------)

## Review Requests(optional):
@seansmith23 

## Please include an emoji of how you feel about this branch:
🤯