### PR TITLE
Api v1 events endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'puma', '~> 3.11'
 gem 'rails', '~> 5.2.3'
 
 group :development, :test do
+  gem 'awesome_print'
   gem 'factory_bot_rails'
   gem 'faker', :git => 'https://github.com/stympy/faker.git', :branch => 'master'
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (9.0.0)
+    awesome_print (1.8.0)
     bootsnap (1.4.4)
       msgpack (~> 1.0)
     builder (3.2.3)
@@ -186,6 +187,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
+  awesome_print
   bootsnap (>= 1.1.0)
   factory_bot_rails
   faker!

--- a/README.md
+++ b/README.md
@@ -205,6 +205,48 @@ body:
   }
 }
 ```
+---
+**GET /api/v1/events**  
+Returns all olympic events, which are displayed under the heading of their associated sport.
 
+Required Parameters:
+`no required parameters`
+
+Example Request:
+`GET https://koroibos-2016.herokuapp.com/api/v1/events`
+```
+Request:
+Content-Type: application/json
+Accept: application/json
+```
+```
+Response:
+status: 200
+body:
+{
+  events: [
+    {
+      sport: "Taekwondo",
+      events: [
+        "Taekwondo Women's Flyweight",
+        "Taekwondo Men's Featherweight",
+        "Taekwondo Men's Heavyweight",
+        "Taekwondo Women's Featherweight",
+        "Taekwondo Women's Heavyweight",
+        "Taekwondo Men's Flyweight",
+        "Taekwondo Women's Welterweight",
+        "Taekwondo Men's Welterweight"
+      ]
+    },
+    {
+      sport: "Handball",
+      events: [
+        "Handball Men's Handball",
+        "Handball Women's Handball"
+      ]
+    }
+  ]  
+}
+```
 ### Schema
 ![schema](korobois_schema.png)

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::EventsController < ApplicationController
+
+  def index
+    render json: Sport.all, each_serializer: SportEventsSerializer, root: 'events'
+  end
+
+end

--- a/app/serializers/sport_events_serializer.rb
+++ b/app/serializers/sport_events_serializer.rb
@@ -1,0 +1,15 @@
+class SportEventsSerializer < ActiveModel::Serializer
+  attributes :sport, :events
+
+  def sport
+    object.sport_name
+  end
+
+  def events
+    event_list = []
+    object.events.each { |event| event_list << event.event_name}
+
+    event_list
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
     namespace :v1 do
       get '/olympians', to: 'olympians#index'
       get '/olympian_stats', to: 'olympian_stats#index'
+
+      get '/events', to: 'events#index'
     end
   end
 

--- a/spec/requests/api/v1/events_request_spec.rb
+++ b/spec/requests/api/v1/events_request_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe 'Events API' do
+
+  context 'GET api/v1/events' do
+    it 'returns all events - along with the sport that they belong to' do
+      archery = create(:sport, sport_name: 'Archery')
+      badminton = create(:sport, sport_name: 'Badminton')
+
+      create(:event, event_name: "Archery Men's Individual", sport: archery)
+      create(:event, event_name: "Archery Men's Team", sport: archery)
+      create(:event, event_name: "Archery Women's Individual", sport: archery)
+      create(:event, event_name: "Archery Women's Team", sport: archery)
+
+      create(:event, event_name: "Badminton Men's Singles", sport: badminton)
+      create(:event, event_name: "Badminton Women's Doubles", sport: badminton)
+      create(:event, event_name: "Badminton Women's Singles", sport: badminton)
+      create(:event, event_name: "Badminton Mixed Doubles", sport: badminton)
+
+      get '/api/v1/events'
+
+      event_data = JSON.parse(response.body)
+
+      expected =  {
+                    "events" =>
+                      [
+                        {
+                          "sport" => "Archery",
+                          "events" => [
+                            "Archery Men's Individual",
+                            "Archery Men's Team",
+                            "Archery Women's Individual",
+                            "Archery Women's Team"
+                          ]
+                        },
+                        {
+                          "sport" => "Badminton",
+                          "events" => [
+                            "Badminton Men's Singles",
+                            "Badminton Women's Doubles",
+                            "Badminton Women's Singles",
+                            "Badminton Mixed Doubles"
+                          ]
+                        }
+                      ]
+                  }
+
+      expect(response.status).to eq(200)
+      expect(event_data).to eq(expected)
+    end
+  end
+
+end


### PR DESCRIPTION
- [ ] Check this if the PR has been approved by the team to be a quick patch and the rest of this form will not be filled out

## What functionality does this accomplish?
closes #10

**Description:**
`GET api/v1/events` : renders JSON, returning all olympic events, which are displayed under the heading of their associated sport.

- Created Spec: `/spec/requests/api/v1/events_request_spec.rb`
- Created Route: `GET /api/v1/events`
- Created Controller: `/api/v1/events_controller.rb`
- Created Serializer:  `/serializers/sport_events_serializer.rb`
- Installed `gem 'awesome_print` to make reading hashes easier in testing.

*Example*:
```
Response:
status: 200
body:
{
  events: [
    {
      sport: "Taekwondo",
      events: [
        "Taekwondo Women's Flyweight",
        "Taekwondo Men's Featherweight",
        "Taekwondo Men's Heavyweight",
        "Taekwondo Women's Featherweight",
        "Taekwondo Women's Heavyweight",
        "Taekwondo Men's Flyweight",
        "Taekwondo Women's Welterweight",
        "Taekwondo Men's Welterweight"
      ]
    },
    {
      sport: "Handball",
      events: [
        "Handball Men's Handball",
        "Handball Women's Handball"
      ]
    }
  ]  
}
```
*Note*:
To follow the project specs this route goes to the `Api::V1::EventsController`. Due to the way that the JSON response needs to be formatted, it made more sense to work with `Sport` objects, which we call `.events` on to return the associated events. That being said, the logic in `events#index` looks a little weird since we are referencing the `Sport` model. 
```
class Api::V1::EventsController < ApplicationController

  def index
    render json: Sport.all, each_serializer: SportEventsSerializer, root: 'events'
  end

end
```
Everything is working clean and fine - just thought it was worth noting. Another option would be to route `GET /api/v1/events` to `sports#index`, but this doesn't feel RESTful.

## What did you struggle on to complete?

## Current Test Suite:
### Test Coverage Percentage: 100%
- [x] Tests have been added
- [ ] No Tests have been changed
- [ ] Some Tests have been changed

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
- [ ] I have partially tested my code (please explain why):

## Helpful Resources:
Resource link AND small description of info gathered/learned
- [Awesome Print Gem Docs](https://github.com/awesome-print/awesome_print) - makes reading hashes a little easier when testing. To use, when calling a variable in from the terminal during testing, prepend with `ap `. *Example*: `pry> ap event_data`

## Review Requests(optional):
@seanmsmith23

## Please include an emoji of how you feel about this branch:
